### PR TITLE
Forward application exit status via reboot syscall

### DIFF
--- a/arch/riscv/kernel/reset.c
+++ b/arch/riscv/kernel/reset.c
@@ -3,8 +3,10 @@
  * Copyright (C) 2012 Regents of the University of California
  */
 
+#include <linux/kernel.h>
 #include <linux/reboot.h>
 #include <linux/pm.h>
+#include <asm/sbi.h>
 
 static void default_power_off(void)
 {
@@ -17,8 +19,13 @@ EXPORT_SYMBOL(pm_power_off);
 
 void machine_restart(char *cmd)
 {
+	int32_t type   = 0,
+		reason = 0;
+
+	if (kstrtoint(cmd, 10, &reason) != 0)
+		type = 1;
 	do_kernel_restart(cmd);
-	while (1);
+	sbi_ecall(SBI_EXT_0_1_SHUTDOWN, 0, type, reason, 0, 0, 0, 0);
 }
 
 void machine_halt(void)

--- a/kernel/reboot.c
+++ b/kernel/reboot.c
@@ -248,9 +248,9 @@ void kernel_restart(char *cmd)
 	migrate_to_reboot_cpu();
 	syscore_shutdown();
 	if (!cmd)
-		pr_emerg("Restarting system\n");
+		pr_notice("Restarting system\n");
 	else
-		pr_emerg("Restarting system with command '%s'\n", cmd);
+		pr_notice("Restarting system with command '%s'\n", cmd);
 	kmsg_dump(KMSG_DUMP_SHUTDOWN);
 	machine_restart(cmd);
 }


### PR DESCRIPTION
Example code to trigger this behavior
```
 #include<stdio.h>
 #include<unistd.h>
 #include<syscall.h>
 #include<linux/reboot.h>

int main(int argc, char *argv[]) {
	const char *bail = argc > 1? argv[1] : "0";
	printf("bail: %s\n", bail);
	syscall(SYS_reboot, LINUX_REBOOT_MAGIC1, LINUX_REBOOT_MAGIC2, LINUX_REBOOT_CMD_RESTART2, bail);
}
```