### PR TITLE
feat: Exit with a non-zero code on panic

### DIFF
--- a/arch/riscv/kernel/reset.c
+++ b/arch/riscv/kernel/reset.c
@@ -19,13 +19,8 @@ EXPORT_SYMBOL(pm_power_off);
 
 void machine_restart(char *cmd)
 {
-	int32_t type   = 0,
-		reason = 0;
-
-	if (kstrtoint(cmd, 10, &reason) != 0)
-		type = 1;
 	do_kernel_restart(cmd);
-	sbi_ecall(SBI_EXT_0_1_SHUTDOWN, 0, type, reason, 0, 0, 0, 0);
+	while (1);
 }
 
 void machine_halt(void)

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -437,7 +437,7 @@ void panic(const char *fmt, ...)
 #endif
 
 #ifdef CONFIG_CARTESI_HALT_ON_PANIC
-machine_halt();
+	machine_restart("255");
 #endif
 
 #if defined(CONFIG_S390)


### PR DESCRIPTION
This requires OpenSBI and the following on `.config`:
```
CONFIG_CARTESI_HALT_ON_PANIC=y
```

close cartesi/machine-emulator#144

```
cartesi-machine.lua --flash-drive=label:root,filename:/tmp/zero.bin
[    0.107456] Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(259,0)
[    0.107776] CPU: 0 PID: 1 Comm: swapper Not tainted 6.5.9-ctsi-1-gdf48295448c3 #190
[    0.108096] Hardware name: ucbbar,riscvemu-bare (DT)
[    0.108288] Call Trace:
[    0.108416] [<ffffffff800045ba>] dump_backtrace+0x1c/0x24
[    0.108672] [<ffffffff803ed578>] show_stack+0x2c/0x38
[    0.108928] [<ffffffff803f34f0>] dump_stack_lvl+0x20/0x32
[    0.109184] [<ffffffff803f3516>] dump_stack+0x14/0x1c
[    0.109440] [<ffffffff803ed6dc>] panic+0xf4/0x286
[    0.109696] [<ffffffff804014c8>] mount_root_generic+0x264/0x282
[    0.109952] [<ffffffff8040164a>] mount_root+0x164/0x180
[    0.110208] [<ffffffff8040181a>] prepare_namespace+0x1b4/0x20c
[    0.110528] [<ffffffff80400f72>] kernel_init_freeable+0x1c4/0x1e0
[    0.110784] [<ffffffff803f434c>] kernel_init+0x20/0x10a
[    0.111040] [<ffffffff80002e36>] ret_from_fork+0xa/0x1c

Halted with payload: 255
Cycles: 23369989
```

verified that `qemu` is halting on panic.