### PR TITLE
Release Linux 6.5.9-ctsi-2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 VERSION = 6
 PATCHLEVEL = 5
 SUBLEVEL = 9
-EXTRAVERSION = -ctsi-1
+EXTRAVERSION = -ctsi-2
 NAME = Hurr durr I'ma ninja sloth
 
 # *DOCUMENTATION*


### PR DESCRIPTION
- reworked drivers for output unification. `rollup` and `yield` drivers got simplified and merged into a single driver `cmio`.